### PR TITLE
Bugfix - Null-pointer exception in combine latest with nullable type

### DIFF
--- a/uikit/views/src/main/java/com/sygic/maps/uikit/views/common/extensions/LiveDataExtensions.kt
+++ b/uikit/views/src/main/java/com/sygic/maps/uikit/views/common/extensions/LiveDataExtensions.kt
@@ -75,21 +75,22 @@ fun <T> LiveData<T>.observeOnce(owner: LifecycleOwner, observer: (T) -> Unit) {
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.
  */
-fun <X, T> combineLatest(first: LiveData<X>, second: LiveData<T>) = combineLatest(first, second) { x, t -> Pair(x, t) }
+fun <A, B> combineLatest(first: LiveData<A>, second: LiveData<B>) = combineLatest(first, second) { a, b -> Pair(a, b) }
 
-fun <X, T, Z> combineLatest(first: LiveData<X>, second: LiveData<T>, combineFunction: (X, T) -> Z) = MediatorLiveData<Z>().apply {
+@Suppress("UNCHECKED_CAST")
+fun <A, B, R> combineLatest(first: LiveData<A>, second: LiveData<B>, combineFunction: (A, B) -> R) = MediatorLiveData<R>().apply {
 
     var firstEmitted = false
-    var firstValue: X? = null
+    var firstValue: A? = null
 
     var secondEmitted = false
-    var secondValue: T? = null
+    var secondValue: B? = null
 
     addSource(first) {
         firstEmitted = true
         firstValue = it
         if (firstEmitted && secondEmitted) {
-            value = combineFunction(firstValue!!, secondValue!!)
+            value = combineFunction(firstValue as A, secondValue as B)
         }
     }
 
@@ -97,7 +98,7 @@ fun <X, T, Z> combineLatest(first: LiveData<X>, second: LiveData<T>, combineFunc
         secondEmitted = true
         secondValue = it
         if (firstEmitted && secondEmitted) {
-            value = combineFunction(firstValue!!, secondValue!!)
+            value = combineFunction(firstValue as A, secondValue as B)
         }
     }
 }
@@ -110,24 +111,25 @@ fun <X, T, Z> combineLatest(first: LiveData<X>, second: LiveData<T>, combineFunc
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.
  */
-fun <X, Y, T> combineLatest(first: LiveData<X>, second: LiveData<Y>, third: LiveData<T>) = combineLatest(first, second, third) { x, y, t -> Triple(x, y, t) }
+fun <A, B, R> combineLatest(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>) = combineLatest(first, second, third) { a, b, c -> Triple(a, b, c) }
 
-fun <X, Y, T, Z> combineLatest(first: LiveData<X>, second: LiveData<Y>, third: LiveData<T>, combineFunction: (X, Y, T) -> Z) = MediatorLiveData<Z>().apply {
+@Suppress("UNCHECKED_CAST")
+fun <A, B, C, R> combineLatest(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>, combineFunction: (A, B, C) -> R) = MediatorLiveData<R>().apply {
 
     var firstEmitted = false
-    var firstValue: X? = null
+    var firstValue: A? = null
 
     var secondEmitted = false
-    var secondValue: Y? = null
+    var secondValue: B? = null
 
     var thirdEmitted = false
-    var thirdValue: T? = null
+    var thirdValue: C? = null
 
     addSource(first) {
         firstEmitted = true
         firstValue = it
         if (firstEmitted && secondEmitted && thirdEmitted) {
-            value = combineFunction(firstValue!!, secondValue!!, thirdValue!!)
+            value = combineFunction(firstValue as A, secondValue as B, thirdValue as C)
         }
     }
 
@@ -135,7 +137,7 @@ fun <X, Y, T, Z> combineLatest(first: LiveData<X>, second: LiveData<Y>, third: L
         secondEmitted = true
         secondValue = it
         if (firstEmitted && secondEmitted && thirdEmitted) {
-            value = combineFunction(firstValue!!, secondValue!!, thirdValue!!)
+            value = combineFunction(firstValue as A, secondValue as B, thirdValue as C)
         }
     }
 
@@ -143,14 +145,14 @@ fun <X, Y, T, Z> combineLatest(first: LiveData<X>, second: LiveData<Y>, third: L
         thirdEmitted = true
         thirdValue = it
         if (firstEmitted && secondEmitted && thirdEmitted) {
-            value = combineFunction(firstValue!!, secondValue!!, thirdValue!!)
+            value = combineFunction(firstValue as A, secondValue as B, thirdValue as C)
         }
     }
 }
 
 /**
  * zips both of the LiveData and emits a value after both of them have emitted their values,
- * after that, emits values whenever any of them emits a value.
+ * after that, waits again for both LiveData to emit new value.
  *
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.
@@ -188,7 +190,7 @@ fun <T, Y, Z> zip(first: LiveData<T>, second: LiveData<Y>, zipFunction: (T, Y) -
 
 /**
  * zips three LiveData and emits a value after all of them have emitted their values,
- * after that, emits values whenever any of them emits a value.
+ * after that, waits again for both LiveData to emit new value.
  *
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.

--- a/uikit/views/src/main/java/com/sygic/maps/uikit/views/common/extensions/LiveDataExtensions.kt
+++ b/uikit/views/src/main/java/com/sygic/maps/uikit/views/common/extensions/LiveDataExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Sygic a.s. All rights reserved.
+ * Copyright (c) 2020 Sygic a.s. All rights reserved.
  *
  * This project is licensed under the MIT License.
  *
@@ -111,7 +111,7 @@ fun <A, B, R> combineLatest(first: LiveData<A>, second: LiveData<B>, combineFunc
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.
  */
-fun <A, B, R> combineLatest(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>) = combineLatest(first, second, third) { a, b, c -> Triple(a, b, c) }
+fun <A, B, C> combineLatest(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>) = combineLatest(first, second, third) { a, b, c -> Triple(a, b, c) }
 
 @Suppress("UNCHECKED_CAST")
 fun <A, B, C, R> combineLatest(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>, combineFunction: (A, B, C) -> R) = MediatorLiveData<R>().apply {

--- a/uikit/views/src/main/java/com/sygic/maps/uikit/views/common/extensions/LiveDataExtensions.kt
+++ b/uikit/views/src/main/java/com/sygic/maps/uikit/views/common/extensions/LiveDataExtensions.kt
@@ -157,21 +157,22 @@ fun <A, B, C, R> combineLatest(first: LiveData<A>, second: LiveData<B>, third: L
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.
  */
-fun <T, Y> zip(first: LiveData<T>, second: LiveData<Y>) = zip(first, second) { t, y -> Pair(t, y) }
+fun <A, B> zip(first: LiveData<A>, second: LiveData<B>) = zip(first, second) { a, b -> Pair(a, b) }
 
-fun <T, Y, Z> zip(first: LiveData<T>, second: LiveData<Y>, zipFunction: (T, Y) -> Z) = MediatorLiveData<Z>().apply {
+@Suppress("UNCHECKED_CAST")
+fun <A, B, R> zip(first: LiveData<A>, second: LiveData<B>, zipFunction: (A, B) -> R) = MediatorLiveData<R>().apply {
 
     var firstEmitted = false
-    var firstValue: T? = null
+    var firstValue: A? = null
 
     var secondEmitted = false
-    var secondValue: Y? = null
+    var secondValue: B? = null
 
     addSource(first) {
         firstEmitted = true
         firstValue = it
         if (firstEmitted && secondEmitted) {
-            value = zipFunction(firstValue!!, secondValue!!)
+            value = zipFunction(firstValue as A, secondValue as B)
             firstEmitted = false
             secondEmitted = false
         }
@@ -181,7 +182,7 @@ fun <T, Y, Z> zip(first: LiveData<T>, second: LiveData<Y>, zipFunction: (T, Y) -
         secondEmitted = true
         secondValue = it
         if (firstEmitted && secondEmitted) {
-            value = zipFunction(firstValue!!, secondValue!!)
+            value = zipFunction(firstValue as A, secondValue as B)
             firstEmitted = false
             secondEmitted = false
         }
@@ -195,24 +196,25 @@ fun <T, Y, Z> zip(first: LiveData<T>, second: LiveData<Y>, zipFunction: (T, Y) -
  * The difference between combineLatest and zip is that the zip only emits after all LiveData
  * objects have a new value, but combineLatest will emit after any of them has a new value.
  */
-fun <T, Y, X> zip(first: LiveData<T>, second: LiveData<Y>, third: LiveData<X>) = zip(first, second, third) { t, y, x -> Triple(t, y, x) }
+fun <A, B, C> zip(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>) = zip(first, second, third) { a, b, c -> Triple(a, b, c) }
 
-fun <T, Y, X, Z> zip(first: LiveData<T>, second: LiveData<Y>, third: LiveData<X>, zipFunction: (T, Y, X) -> Z) = MediatorLiveData<Z>().apply {
+@Suppress("UNCHECKED_CAST")
+fun <A, B, C, R> zip(first: LiveData<A>, second: LiveData<B>, third: LiveData<C>, zipFunction: (A, B, C) -> R) = MediatorLiveData<R>().apply {
 
     var firstEmitted = false
-    var firstValue: T? = null
+    var firstValue: A? = null
 
     var secondEmitted = false
-    var secondValue: Y? = null
+    var secondValue: B? = null
 
     var thirdEmitted = false
-    var thirdValue: X? = null
+    var thirdValue: C? = null
 
     addSource(first) {
         firstEmitted = true
         firstValue = it
         if (firstEmitted && secondEmitted && thirdEmitted) {
-            value = zipFunction(firstValue!!, secondValue!!, thirdValue!!)
+            value = zipFunction(firstValue as A, secondValue as B, thirdValue as C)
             firstEmitted = false
             secondEmitted = false
             thirdEmitted = false
@@ -226,7 +228,7 @@ fun <T, Y, X, Z> zip(first: LiveData<T>, second: LiveData<Y>, third: LiveData<X>
             firstEmitted = false
             secondEmitted = false
             thirdEmitted = false
-            value = zipFunction(firstValue!!, secondValue!!, thirdValue!!)
+            value = zipFunction(firstValue as A, secondValue as B, thirdValue as C)
         }
     }
 
@@ -237,7 +239,7 @@ fun <T, Y, X, Z> zip(first: LiveData<T>, second: LiveData<Y>, third: LiveData<X>
             firstEmitted = false
             secondEmitted = false
             thirdEmitted = false
-            value = zipFunction(firstValue!!, secondValue!!, thirdValue!!)
+            value = zipFunction(firstValue as A, secondValue as B, thirdValue as C)
         }
     }
 }


### PR DESCRIPTION
Generics are nullable so it's valid to combine LiveData with nullable type eg. `LiveData<String?>`. Combine function with `!!` will incorrectly throw an exception when `null` value comes around